### PR TITLE
Rails.application.config.active_record.belongs_to_required_by_default…

### DIFF
--- a/lib/bootsy/activerecord/image_gallery.rb
+++ b/lib/bootsy/activerecord/image_gallery.rb
@@ -10,7 +10,8 @@ module Bootsy
   # that do not point to resources older than the given time
   # limit.
   class ImageGallery < ActiveRecord::Base
-    belongs_to :bootsy_resource, polymorphic: true, autosave: false
+    belongs_to :bootsy_resource, polymorphic: true, autosave: false,
+                                 optional: true
     has_many :images, dependent: :destroy
 
     scope :destroy_orphans, lambda { |time_limit|


### PR DESCRIPTION
… is set to `true` for new Rails 5 app as mentioned in https://github.com/volmer/bootsy/issues/243.

http://blog.bigbinary.com/2016/02/15/rails-5-makes-belong-to-association-required-by-default.html